### PR TITLE
WIP - Feature/find or create receiver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.70.0)
+    rubocop (0.71.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -359,7 +359,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webpacker (4.0.4)
+    webpacker (4.0.5)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)

--- a/app/models/receiver.rb
+++ b/app/models/receiver.rb
@@ -7,4 +7,18 @@ class Receiver < ApplicationRecord
   def to_name
     "#{first_name} #{last_name}".strip
   end
+
+  def self.find_or_enroll(message_vo)
+    receiver = Receiver.find_by(receiver_sso_id: message_vo.receiver_sso_id)
+    if receiver.nil?
+      # Create receiver
+      receiver = Receiver.create!(
+          receiver_sso_id: message_vo.receiver_sso_id,
+          email: message_vo.receiver_email
+      )
+      # Lookup sso user by email and assign delivery preference, fname, lname
+
+    end
+    receiver
+  end
 end

--- a/app/services/highlands.rb
+++ b/app/services/highlands.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+class Highlands
+  # rubocop:disable all
+  def self.link_highlands_msg_to_message(message_id, highlands_msg_id)
+    highlands_msg = HighlandsMsg.find_by(id: highlands_msg_id)
+    if highlands_msg.nil?
+      log_error("Unable to find highlands_msg (#{highlands_msg_id}). Did not link message (#{message_id})")
+      return false
+    end
+    message = Message.find_by(id: message_id)
+    if message.nil?
+      log_error("Unable to find message (#{message_id}). Did not link highlands_msg (#{highlands_msg_id})")
+      return false
+    end
+    message.highlands_msg_id = highlands_msg_id
+    message.save!
+  end
+
+  # def self.get_user(data)
+  #   response = HighlandsClient::MessageClient.new(data: data[:highlands_data],
+  #                                                   resource: 'messages').send_message
+  #
+  #   highlands_msg = HighlandsMsg.create!(sent_to_highlands: Time.now,
+  #                                            response: { response: response['data'] })
+  #
+  #   highlands_msg.got_response_at = Time.now
+  #   highlands_msg.status = response['data']['status']
+  #
+  #   if highlands_msg.save! && link_highlands_msg_to_message(data[:message_id], highlands_msg.id)
+  #     return ReturnVo.new(value: return_accepted("highlands_msg": highlands_msg), error: nil)
+  #   else
+  #     err = highlands_msg.errors || "Error for highlands_id (#{highlands_id})"
+  #     return ReturnVo.new(value: nil, error: return_error(err, :unprocessable_entity))
+  #   end
+  # end
+
+  def get_user(data)
+    data = data[:highlands_data]
+    response = HighlandsClient::MessageClient.new(data: data,
+                                                  resource: data[:resource]).get_user(data[:email])
+
+    preferred_communications = response['data']['communications']['communication'].select{ |item| item['preferred'] == 'true' }
+    mobile_communications = preferred_communications.select{ |item| item['communicationType']['name'] == 'Mobile'}
+    email_communications = preferred_communications.select{ |item| item['communicationGeneralType'] == 'Email'}
+    mobile_phones = mobile_communications.map{|item| item['communicationValue']}
+    emails = email_communications.map{|item| item['communicationValue']}
+
+    ap response
+    if !err.nil?
+      msg = 'GET highlands user Error'
+      return ReturnVo.new(value: nil, error: return_error(msg, :unprocessable_entity))
+    else
+      preferred_communications = {
+          communications: {
+              mobile_phones: mobile_phones,
+              emails: emails
+          }
+      }
+      return ReturnVo.new(value: return_accepted(preferred_communications: preferred_communications), error: nil)
+    end
+
+  end
+
+
+  def self.get_user_by_email(email)
+    # Populate and sanitize data
+    data = {
+            resource: 'search_by_email',
+            email: email,
+    }
+    get_user(highlands_data: data)
+  rescue StandardError => e
+    err_msg = JSON.parse(e.message)['error']['message']
+    err_msg = JSON.parse(e.message)['error']['msg'] if err_msg.nil?
+    # Log Highlands subscription warnings if necessary. Note Uhura does not submit create_subscriber requests.
+    if err_msg.include?('supplied subscribers is invalid') # "At least one of the supplied subscribers is invalid."
+      # If the subscriber is invalid, let's assume that they've not been registered with Highlands.io
+      # So, an entity outside of Uhura should create the subscriber see that they opt in before returning to Uhura.
+      action_msg = {
+        "error_from_highlands": err_msg,
+        "assumed_meaning": "This receiver w/ mobile_number (#{message_vo.mobile_number}) not registered in Highlands",
+        "action": "Research whether receiver_sso_id (#{message_vo.receiver_sso_id}) is valid."
+      }
+      log_warn(action_msg)
+      err_msg = {
+        "msg": err_msg,
+        "action_required:": action_msg
+      }
+    elsif err_msg.include?('You must send your message to at least one subscriber')
+      # Since Uhura does not submit subscription requests, this block should never be executed
+      action_msg = {
+        "error_from_highlands": err_msg,
+        "action": "Research status of Highlands subscription for receiver_sso_id (#{message_vo.receiver_sso_id})"
+      }
+      log_warn(action_msg)
+      err_msg = {
+        "msg": err_msg,
+        "action_required:": action_msg
+      }
+    end
+    # Handle error in caller
+    ReturnVo.new(value: nil, error: return_error(err_msg, :unprocessable_entity))
+  end
+  # rubocop:enable all
+end

--- a/app/services/message_vo.rb
+++ b/app/services/message_vo.rb
@@ -52,7 +52,8 @@ class MessageVo
 
     # Valid input. Now, perform lookups to fill in missing data prior to processing request.
     assign_attributes(message_params_vo.my_attrs.merge(manager_team_vo.my_attrs))
-    receiver = Receiver.find_by(receiver_sso_id: receiver_sso_id)
+
+    receiver = Receiver.find_or_enroll(receiver_sso_id)
     if receiver
       self.receiver_id = receiver.id # Required by  Message.create!
       # Following message_vo attributes required by ClearstreamClient::MessageClient.create_subscriber

--- a/app/services/message_vo.rb
+++ b/app/services/message_vo.rb
@@ -53,8 +53,22 @@ class MessageVo
     # Valid input. Now, perform lookups to fill in missing data prior to processing request.
     assign_attributes(message_params_vo.my_attrs.merge(manager_team_vo.my_attrs))
 
-    receiver = Receiver.find_or_enroll(receiver_sso_id)
-    if receiver
+    receiver = Receiver.find_by(receiver_sso_id: @receiver_sso_id)
+    if receiver.nil?
+      # Create Receiver
+      user = Highlands.get_user_by_email(message_vo.email)
+      if user.error
+        msg = user.error[:error]
+        log_error(msg)
+      else
+        msg = "Sent SMS: (#{message_vo.team_name}:#{message_vo.email_subject}) "
+        msg += "from (#{message_vo.manager_name}) to (#{message_vo.mobile_number})"
+        log_info(msg)
+      end
+
+
+    else
+      # Receiver already exists
       self.receiver_id = receiver.id # Required by  Message.create!
       # Following message_vo attributes required by ClearstreamClient::MessageClient.create_subscriber
       self.mobile_number = receiver.mobile_number

--- a/lib/highlands_client.rb
+++ b/lib/highlands_client.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Base
+require 'highlands_client/config'
+require 'highlands_client/version'
+require 'highlands_client/json_converter'
+require 'highlands_client/conversion_helper'
+
+# Clients
+require 'highlands_client/clients/base_client'
+require 'highlands_client/clients/message_client'
+require 'highlands_client/clients/list_client'
+
+# Resources
+require 'highlands_client/resources/base_resource'
+require 'highlands_client/resources/message'
+require 'highlands_client/resources/list'

--- a/lib/highlands_client/clients/base_client.rb
+++ b/lib/highlands_client/clients/base_client.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'faraday_middleware'
+
+module HighlandsClient
+  class BaseClient
+    APIError = Class.new(StandardError)
+    CS_BASE_URL = HighlandsClient::Config.base_url
+
+    def initialize(options = {})
+      @data = options[:data]
+      @api_key = ENV['SSO_KEY']
+      @resource = options[:resource]
+    end
+
+    def search_by_email(email)
+      # Build and send request
+      response = connection.get do |req|
+        req.url "#{CS_BASE_URL}/#{@resource}/?email=#{email}"
+      end
+      raise APIError, response.body unless response.success?
+      raise APIError, response.body if response.status.eql?(204) # No Content
+
+      JSONConverter.to_hash(response.body)
+    end
+
+    private
+
+    # rubocop:disable Layout/AlignHash
+    def headers
+      {
+        'Authorization' => "Token token=#{@api_key.to_s}",
+        'Content-Type' => 'application/json'
+      }
+    end
+    # rubocop:enable Layout/AlignHash
+
+    def connection
+      Faraday.new(url: HighlandsClient::Config.base_url, headers: headers) do |builder|
+        builder.request :json
+        builder.adapter :typhoeus # typphous is much faster than net_http
+      end
+    end
+  end
+end

--- a/lib/highlands_client/clients/list_client.rb
+++ b/lib/highlands_client/clients/list_client.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  class ListClient < BaseClient
+    # Nothing custom here!
+  end
+end

--- a/lib/highlands_client/clients/message_client.rb
+++ b/lib/highlands_client/clients/message_client.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  # rubocop:disable all
+  class MessageClient < BaseClient
+    alias get_user search_by_email
+
+    def self.create_subscriber(data)
+      new_subscriber_data = {
+        'mobile_number': data.mobile_number,
+        'first': data.first,
+        'last': data.last,
+        'email': data.receiver_email,
+        'lists': data.lists,
+        'autoresponse_header': 'Higlands SMS',
+        'autoresponse_body': 'Your SMS Opt-in setting has been updated.'
+      }
+      base_client = HighlandsClient::BaseClient.new(data: new_subscriber_data, resource: 'subscribers')
+      begin
+        response = base_client.create
+      rescue APIError => e
+        msg = "Failed to create subscriber. Highlands response: #{response.to_json}. APIError: #{e.message}"
+        log_error(msg)
+        return ReturnVo.new(value: nil, error: return_error(msg, :unprocessable_entity))
+      end
+      msg = "Requested Highlands to create subscriber (#{new_subscriber_data.to_json}). Resonse: #{response.to_json}"
+      log_info(msg)
+      # TODO: Verify that this status is correct when Highlands.io support increases subscriber limit
+      if response['data']['status'] == 'QUEUED'
+        return ReturnVo.new(value: return_accepted("highlands_msg": highlands_msg.to_json), error: nil)
+      else
+        msg = "Failed to create subscriber. Highlands response: #{response.to_json}"
+        log_error(msg)
+        return ReturnVo.new(value: nil, error: return_error(msg, :unprocessable_entity))
+      end
+    end
+  end
+end

--- a/lib/highlands_client/config.rb
+++ b/lib/highlands_client/config.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  class Config
+    def self.base_url
+      ENV['HIGHLANDS_BASE_URL'] || 'https://sso.highlandsapp.com/api/v1'
+    end
+  end
+end

--- a/lib/highlands_client/conversion_helper.rb
+++ b/lib/highlands_client/conversion_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ConversionHelper
+  def methodize_attributes(*methods)
+    h = {}
+    methods.each { |m| h[m] = send(m) }
+    h
+  end
+end

--- a/lib/highlands_client/json_converter.rb
+++ b/lib/highlands_client/json_converter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class JSONConverter
+  def self.to_hash(json)
+    return JSON.parse(json) if json.class == String
+
+    json
+  end
+end

--- a/lib/highlands_client/resources/base_resource.rb
+++ b/lib/highlands_client/resources/base_resource.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'faraday_middleware'
+
+module HighlandsClient
+  class BaseResource
+    include ConversionHelper
+    include ActiveModel::Validations
+  end
+end

--- a/lib/highlands_client/resources/list.rb
+++ b/lib/highlands_client/resources/list.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  class List < BaseResource
+    validates :name, presence: true
+
+    attr_accessor :id, :name
+
+    def initialize(attributes = {})
+      deserialize(attributes['data'])
+    end
+
+    # Method for @data (to convert HighlandsClient::Messaage and ::List objects) to a hash of callable attributes
+    def to_h
+      methodize_attributes(:id, :lastName)
+    end
+
+    private
+
+    def deserialize(json)
+      self.id = json['id']
+      self.name = json['lastName']
+      self
+    end
+  end
+end

--- a/lib/highlands_client/resources/message.rb
+++ b/lib/highlands_client/resources/message.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  class Message < BaseResource
+    validates :template_id, presence: true
+    validates :message_body, presence: true
+    validates :schedule, inclusion: [true, false]
+    validates :send_to_fb, inclusion: [true, false]
+    validates :send_to_tw, inclusion: [true, false]
+
+    attr_accessor :id,
+                  :template_id,
+                  :message_body,
+                  :lists,
+                  :subscribers,
+                  :schedule,
+                  :datetime,
+                  :timezone,
+                  :send_to_fb,
+                  :send_to_tw
+
+    def initialize(attributes = {})
+      deserialize(attributes['message'])
+    end
+
+    def to_h
+      methodize_attributes(:id,
+                           :template_id,
+                           :message_body,
+                           :lists,
+                           :subscribers,
+                           :schedule,
+                           :datetime,
+                           :timezone,
+                           :send_to_fb,
+                           send_to_tw)
+    end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def deserialize(json)
+      self.id = json['id']
+      self.template_id = json['template_id']
+      self.message_body = json['message_body']
+      self.lists = json['lists']
+      self.subscribers = json['subscribers']
+      self.schedule = json['schedule']
+      self.datetime = json['datetime']
+      self.timezone = json['timezone']
+      self.send_to_fb = json['send_to_fb']
+      self.send_to_tw = json['send_to_tw']
+      self
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/lib/highlands_client/version.rb
+++ b/lib/highlands_client/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module HighlandsClient
+  VERSION = '1.0.0'
+end

--- a/spec/models/receiver_spec.rb
+++ b/spec/models/receiver_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe Receiver, type: :model do
       expect(receiver.email).to match(URI::MailTo::EMAIL_REGEXP)
     end
   end
+
+  describe 'find_or_enroll' do
+    it { is_expected.to validate_presence_of(:mobile_number) }
+  end
 end

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -16,4 +16,3 @@ module ControllerSpecHelper
     }
   end
 end
-  


### PR DESCRIPTION
Currently blocked because we don't have a way to get a user's email address.

The *people* API (ex: https://sso.highlandsapp.com/api/v1/people/58034259)  does not return a person's email address.   We need a person's email address in order to call the *search_by_email* API (ex: https://sso.highlandsapp.com/api/v1/search_by_email?email=charles@churchofthehighlands.com).  

It's the search_by_email endpoint that provides all communication information we need.

NOTE:
A typical request looks like this:
```
{
    "public_token": "42c50c442ee3ca01378e",
    "receiver_sso_id": "88543891",
    "email_subject": "Picnic Saturday",
    "email_message": {
      "header": "Dragon Rage",
      "section1": "imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.",
      "button": "Count me in!"
    },
    "template_id": "d-f986df533e514f978f4460bedca50db0",
    "sms_message": "Come in now for 50% off all rolls!"
}
```
It has the `receiver_sso_id` ... and we currently do not have a way to get from that to an `email_address`.

**Other logic updates TBD**:

The data model within F1 (member db) does allow multiple 'preferred' methods of comms, given that a household has many members. Fine to send to all that are marked in that way. - Charles H.