### PR TITLE
Handle sendgrid_options_key (to pass along options to sendgrid)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1668,7 +1668,7 @@ Metrics/ClassLength:
   Enabled: true
   VersionAdded: '0.25'
   CountComments: false  # count full line comments?
-  Max: 100
+  Max: 140
 
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -31,6 +31,7 @@ class Api::V1::MessagesController < Api::V1::ApiBaseController
       receiver_sso_id: params[:receiver_sso_id],
       email_subject: params[:email_subject],
       email_message: params[:email_message],
+      email_options: params[:email_options],
       template_id: params[:template_id],
       sms_message: params[:sms_message]
     )

--- a/app/dashboards/message_dashboard.rb
+++ b/app/dashboards/message_dashboard.rb
@@ -19,6 +19,7 @@ class MessageDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email_subject: Field::String,
     email_message: Field::Text,
+    email_options: Field::String.with_options(searchable: false),
     sms_message: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -48,6 +49,7 @@ class MessageDashboard < Administrate::BaseDashboard
     id
     email_subject
     email_message
+    email_options
     sms_message
     created_at
     updated_at
@@ -65,6 +67,7 @@ class MessageDashboard < Administrate::BaseDashboard
     template
     email_subject
     email_message
+    email_options
     sms_message
   ].freeze
 

--- a/app/services/message_director.rb
+++ b/app/services/message_director.rb
@@ -61,6 +61,7 @@ class MessageDirector
                                   team_id: message_vo.team_id, # <= message coming from this team
                                   email_subject: message_vo.email_subject,
                                   email_message: message_vo.email_message,
+                                  email_options: message_vo.email_options,
                                   template_id: message_vo.template_id,
                                   sms_message: message_vo.sms_message)
 

--- a/app/services/message_params_vo.rb
+++ b/app/services/message_params_vo.rb
@@ -19,6 +19,7 @@ class MessageParamsVo < BaseClass
                 :receiver_sso_id,
                 :email_subject,
                 :email_message,
+                :email_options,
                 :template_id,
                 :sms_message,
                 :my_attributes
@@ -42,6 +43,7 @@ class MessageParamsVo < BaseClass
       receiver_sso_id: @receiver_sso_id,
       email_subject: @email_subject,
       email_message: @email_message,
+      email_options: @email_options,
       template_id: @template_id,
       sms_message: @sms_message
     }

--- a/app/services/message_vo.rb
+++ b/app/services/message_vo.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 # This is a value object that also performs data presence validation
 class MessageVo
   InvalidMessageError = Class.new(StandardError)
@@ -71,8 +70,6 @@ class MessageVo
         msg += "from (#{message_vo.manager_name}) to (#{message_vo.mobile_number})"
         log_info(msg)
       end
-
-
     else
       # Receiver already exists
       self.receiver_id = receiver.id # Required by  Message.create!

--- a/app/services/message_vo.rb
+++ b/app/services/message_vo.rb
@@ -36,6 +36,7 @@ class MessageVo
                 :receiver_email, # Populated when receiver_sso_id is assigned a value
                 :email_subject,
                 :email_message,
+                :email_options,
                 :template_id, # ID to templates table
                 :sendgrid_template_id,
                 :sms_message,
@@ -118,6 +119,7 @@ class MessageVo
         team_id: self.team_id,
         email_subject: self.email_subject,
         email_message: self.email_message,
+        email_options: self.email_options,
         template_id: self.template_id,
         sms_message: self.sms_message
     }

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -58,9 +58,9 @@ class SendgridHandler < ServiceHandlerBase
         receiver_sso_id: message_vo.receiver_sso_id,
         template_id: message_vo.sendgrid_template_id,
         dynamic_template_data: template_data,
+        email_options: message_vo.email_options,
         message_id: message_vo.message_id
     ).get_vo
-
 
     #SendgridHandler.send_msg(sendgrid_vo)
     SendSendgridMessageWorker.perform_async(sendgrid_vo)

--- a/app/services/sendgrid_mail_vo.rb
+++ b/app/services/sendgrid_mail_vo.rb
@@ -4,6 +4,7 @@ require 'sendgrid-ruby'
 include SendGrid
 
 class SendgridMailVo
+  InvalidEmailOptionError = Class.new(StandardError)
   Invalid = Class.new(StandardError)
   include ActiveModel::Model
   include ActiveModel::Validations
@@ -12,6 +13,7 @@ class SendgridMailVo
                 :to,
                 :to_name,
                 :subject,
+                :email_options,
                 :template_id,
                 :dynamic_template_data,
                 :message_id
@@ -51,19 +53,67 @@ class SendgridMailVo
       subject: @subject,
       to: @to,
       to_name: @to_name,
-      dynamic_template_data: @dynamic_template_data
+      dynamic_template_data: @dynamic_template_data,
+      email_options: @email_options
     }
+    # # Add options, e.g., cc, bcc, reply_to, send_at, batch_id
+    # @email_options.each do |k, v|
+    #   mail_vo[k] = v
+    # end
+
     # Bug in Sendgrid's add_custom_arg.  Following will throw error "no implicit conversion of String into Hash"
     # mail.add_custom_arg(Hash["custom_arg" => {message_id: @message_id}])
     { mail_vo: mail_vo, message_id: @message_id }
   end
 
+  def self.add_options(mail_vo, mail, personalization)
+    email_options = JSON.parse(mail_vo[:email_options].to_json) # Convert from ActionController::Parameters
+    email_options.each do |k, v|
+      case k
+      when 'cc'
+        # ["recipient1@example.com <Alice Recipient>","recipient2@example.com"]
+        v.each do |i|
+          cc_maybe_name_ary = i.strip.gsub('  ', ' ').split(' ')
+          cc = cc_maybe_name_ary[0]
+          cc_name = cc_maybe_name_ary[1..-1].join(' ')[1..-2] if cc_maybe_name_ary.size > 1
+          personalization.add_cc(Email.new(email: cc, name: cc_name))
+        end
+      when 'bcc'
+        # ["recipient3@example.com","recipient4@example.com <Bob Recipient>"]
+        v.each do |i|
+          bcc_maybe_name_ary = i.strip.gsub('  ', ' ').split(' ')
+          bcc = bcc_maybe_name_ary[0]
+          bcc_name = bcc_maybe_name_ary[1..-1].join(' ')[1..-2] if bcc_maybe_name_ary.size > 1
+          personalization.add_bcc(Email.new(email: bcc, name: bcc_name))
+        end
+      when 'reply_to'
+        reply_to_maybe_name_ary = v.strip.gsub('  ', ' ').split(' ')
+        reply_to = reply_to_maybe_name_ary[0]
+        reply_to_name = reply_to_maybe_name_ary[1..-1].join(' ')[1..-2] if reply_to_maybe_name_ary.size > 1
+        mail.reply_to = Email.new(email: reply_to, name: reply_to_name)
+      when 'send_at'
+        mail.send_at = v
+      when 'batch_id'
+        mail.batch_id = v
+      else
+        raise InvalidEmailOptionError, "unknown email option received {#{k}: #{v}}"
+      end
+    end
+    {mail: mail, personalization: personalization}
+  end
+
   def self.get_mail(mail_vo)
     mail = SendGrid::Mail.new
+    personalization = Personalization.new
+    # Add options
+    m_and_p = add_options(mail_vo, mail, personalization)
+    mail = m_and_p[:mail]
+    personalization = m_and_p[:personalization]
+    # Set base mail attributes
     mail.template_id = mail_vo[:template_id]
     mail.from = Email.new(email: mail_vo[:from])
     mail.subject = mail_vo[:subject]
-    personalization = Personalization.new
+    # Set base personalization attributes
     personalization.add_to(Email.new(email: mail_vo[:to], name: mail_vo[:to_name]))
     personalization.add_dynamic_template_data(mail_vo[:dynamic_template_data])
     mail.add_personalization(personalization)

--- a/db/migrate/20190509014853_create_messages.rb
+++ b/db/migrate/20190509014853_create_messages.rb
@@ -9,6 +9,7 @@ class CreateMessages < ActiveRecord::Migration[6.0]
       t.references :team, null: false, foreign_key: true
       t.string :email_subject
       t.text :email_message
+      t.json :email_options
       t.references :template, null: false, foreign_key: true
       t.text :sms_message
 

--- a/db/migrate/20190509014854_create_invalid_messages.rb
+++ b/db/migrate/20190509014854_create_invalid_messages.rb
@@ -7,6 +7,7 @@ class CreateInvalidMessages < ActiveRecord::Migration[6.0]
       t.references :team, null: true
       t.string :email_subject
       t.text :email_message
+      t.json :email_options
       t.references :template, null: true
       t.text :sms_message
       t.json :message_params # params has sent to messages_controller

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_05_12_215905) do
     t.bigint "team_id"
     t.string "email_subject"
     t.text "email_message"
+    t.json "email_options"
     t.bigint "template_id"
     t.text "sms_message"
     t.json "message_params"
@@ -73,6 +74,7 @@ ActiveRecord::Schema.define(version: 2019_05_12_215905) do
     t.bigint "team_id", null: false
     t.string "email_subject"
     t.text "email_message"
+    t.json "email_options"
     t.bigint "template_id", null: false
     t.text "sms_message"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
Ready for review.

Handle sendgrid_options_key (to pass along options to sendgrid)
- Add email_options to
-- MessagesController as new param
-- Admin dashboard for Messages
-- Message and InvalidMessage tables as new field
-- MessageParamsVo
-- MessageVo
-- SendgridMailVo
--- Throw InvalidEmailOptionError if an invalid email option is passed
- New email options include: cc, bcc, reply_to, send_at, batch_id