### PR TITLE
Fix/remove useless sendgrid  x-message-id attribute

### DIFF
--- a/app/dashboards/sendgrid_msg_dashboard.rb
+++ b/app/dashboards/sendgrid_msg_dashboard.rb
@@ -10,7 +10,7 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::Number,
+    id: Field::String.with_options(searchable: false),
     sent_to_sendgrid: Field::DateTime,
     mail_and_response: Field::String.with_options(searchable: false),
     got_response_at: Field::DateTime,

--- a/app/services/sendgrid_mailer.rb
+++ b/app/services/sendgrid_mailer.rb
@@ -14,7 +14,6 @@ class SendgridMailer
     {
       response: {
         body: body,
-        x_message_id: response&.headers && response&.headers['x-message-id'] && response&.headers['x-message-id'][0],
         server_date: response&.headers && response&.headers['date'] && response&.headers['date'][0],
         status_code: response.status_code
       },

--- a/db/migrate/20190509014841_create_sendgrid_msgs.rb
+++ b/db/migrate/20190509014841_create_sendgrid_msgs.rb
@@ -2,7 +2,6 @@ class CreateSendgridMsgs < ActiveRecord::Migration[6.0]
   def change
     create_table :sendgrid_msgs, id: :uuid do |t|
       t.datetime :sent_to_sendgrid
-      t.string :x_message_id
       t.json :mail_and_response
       t.datetime :got_response_at
       t.text :sendgrid_response


### PR DESCRIPTION
We're using the custom_arg personalization attribute for email correlation.  This x-message-id attribute is completely useless.