### PR TITLE
Fix/sendgrid dynamic template subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,5 @@ yarn-debug.log*
 /.RubyMine
 /.env
 /.idea
-/.java
+/*.java
 *.vmoptions
-*.DS_Store
-*.rdb

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -14,11 +14,11 @@ class Api::V1::MessagesController < Api::V1::ApiBaseController
       render_error_msg(err)
     else
       message_vo = MessageVo.new(message_params_vo, manager_team_vo)
-      if !message_vo.errors.blank?
+      if !message_vo.valid?
         render_message_director_error(message_vo)
       else
         return_vo = MessageDirector.send(message_vo)
-        if return_vo.error?
+        if return_vo&.error?
           render_message_director_error(message_vo)
         else
           render_success_status(message_vo.message_id)
@@ -46,7 +46,7 @@ class Api::V1::MessagesController < Api::V1::ApiBaseController
     invalid_message = InvalidMessage.create!(
       message_vo.invalid_message_attrs.merge(
         message_params: message_params_vo.message_params,
-        message_attrs: message_vo.to_hash
+        message_attrs: message_vo.to_hash.merge(errors: message_vo&.errors&.messages[:value])
       )
     )
     render_error_status(invalid_message.id)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -43,10 +43,11 @@ class Api::V1::MessagesController < Api::V1::ApiBaseController
   private
 
   def render_message_director_error(message_vo)
+    errors = message_vo.errors.messages[:value] if message_vo&.errors&.messages
     invalid_message = InvalidMessage.create!(
       message_vo.invalid_message_attrs.merge(
         message_params: message_params_vo.message_params,
-        message_attrs: message_vo.to_hash.merge(errors: message_vo&.errors&.messages[:value])
+        message_attrs: message_vo.to_hash.merge(errors: errors)
       )
     )
     render_error_status(invalid_message.id)

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -4,18 +4,17 @@ class Api::V1::WebHooksController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def sendgrid
-    puts "\n\n>> WebHooksController.sendgrid called params['_json']: #{params['_json']}\n\n"
-    # sendgrid send us an array and this is the way rails does that
+    # Rails automatically handles the JSON data and maps it into the object:  params["_json"]
     events = params['_json']
     events&.each do |event|
       status = event['event']
       message_id = event['uhura_msg_id']
-      #UpdateSendgridMsgStatusFromWebhookWorker.perform_async(message_id, status)
-      tmp_perform_sendgrid_task(message_id, status)
+      # perform_sync_sendgrid_task(message_id, status) # <= Uncomment to test synchronously
+      UpdateSendgridMsgStatusFromWebhookWorker.perform_async(message_id, status)
     end
   end
 
-  def tmp_perform_sendgrid_task(message_id, status)
+  def perform_sync_sendgrid_task(message_id, status)
     sendgrid_msg = SendgridMsg.find(message_id)
     if sendgrid_msg
       sendgrid_msg.status = status
@@ -25,17 +24,14 @@ class Api::V1::WebHooksController < ApplicationController
     end
   end
 
-
   def clearstream
-    puts ">> WebHooksController.clearstream called params['_json']: #{params['_json']}"
-
-    clearstream_id = params[:data][:message][:id]
     status = params[:data][:message][:status]
-    #UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg_id, status)
-    tmp_perform_clearstream_task(clearstream_id, status)
+    clearstream_id = params[:data][:message][:id]
+    # perform_sync_clearstream_task(clearstream_id, status) # <= Uncomment to test synchronously
+    UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_id, status)
   end
 
-  def tmp_perform_clearstream_task(clearstream_id, status)
+  def perform_sync_clearstream_task(clearstream_id, status)
     clearstream_msg = ClearstreamMsg.find_by(clearstream_id: clearstream_id)
     if clearstream_msg
       clearstream_msg.status = status

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -4,18 +4,44 @@ class Api::V1::WebHooksController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def sendgrid
+    puts "\n\n>> WebHooksController.sendgrid called params['_json']: #{params['_json']}\n\n"
     # sendgrid send us an array and this is the way rails does that
     events = params['_json']
     events&.each do |event|
       status = event['event']
       message_id = event['uhura_msg_id']
-      UpdateSendgridMsgStatusFromWebhookWorker.perform_async(message_id, status)
+      #UpdateSendgridMsgStatusFromWebhookWorker.perform_async(message_id, status)
+      tmp_perform_sendgrid_task(message_id, status)
     end
   end
 
+  def tmp_perform_sendgrid_task(message_id, status)
+    sendgrid_msg = SendgridMsg.find(message_id)
+    if sendgrid_msg
+      sendgrid_msg.status = status
+      sendgrid_msg.save!
+    else
+      log_warn("WebHooksController - SendgridMsg.find(#{message_id}) not found!")
+    end
+  end
+
+
   def clearstream
-    clearstream_msg_id = params[:data][:message][:id]
+    puts ">> WebHooksController.clearstream called params['_json']: #{params['_json']}"
+
+    clearstream_id = params[:data][:message][:id]
     status = params[:data][:message][:status]
-    UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg_id, status)
+    #UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg_id, status)
+    tmp_perform_clearstream_task(clearstream_id, status)
+  end
+
+  def tmp_perform_clearstream_task(clearstream_id, status)
+    clearstream_msg = ClearstreamMsg.find_by(clearstream_id: clearstream_id)
+    if clearstream_msg
+      clearstream_msg.status = status
+      clearstream_msg.save!
+    else
+      log_warn("WebHooksController - ClearstreamMsg.find(#{clearstream_id}) not found!")
+    end
   end
 end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -14,6 +14,7 @@ class Api::V1::WebHooksController < ApplicationController
     end
   end
 
+  # TODO: Lex - Remove before Uhura goes live
   def perform_sync_sendgrid_task(message_id, status)
     sendgrid_msg = SendgridMsg.find(message_id)
     if sendgrid_msg
@@ -31,6 +32,7 @@ class Api::V1::WebHooksController < ApplicationController
     UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_id, status)
   end
 
+  # TODO: Lex - Remove before Uhura goes live
   def perform_sync_clearstream_task(clearstream_id, status)
     clearstream_msg = ClearstreamMsg.find_by(clearstream_id: clearstream_id)
     if clearstream_msg

--- a/app/models/message_vo.rb
+++ b/app/models/message_vo.rb
@@ -106,7 +106,7 @@ class MessageVo
   end
 
   def template_found
-    sendgrid_template = Template.find(template_id)
+    sendgrid_template = Template.find_by(id: template_id)
     if sendgrid_template.nil?
       msg = "Template ID (#{template_id}) not found. If it is valid, add it via the Admin application."
       log_error(msg)

--- a/app/services/clearstream_handler.rb
+++ b/app/services/clearstream_handler.rb
@@ -12,8 +12,8 @@ class ClearstreamHandler < ServiceHandlerBase
         message_id: message_vo.message_id
     ).get
 
-    ClearstreamHandler.send_msg(clearstream_vo) # <= Uncomment to test synchronously
-    #ClearstreamMessageWorker.perform_async(clearstream_vo)
+    # ClearstreamHandler.send_msg(clearstream_vo) # <= Uncomment to test synchronously
+    ClearstreamMessageWorker.perform_async(clearstream_vo)
 
     msg = "Asynchronously sent SMS: (#{message_vo.team_name}:#{message_vo.email_subject}) "
     msg += "from (#{message_vo.manager_name}) to (#{message_vo.mobile_number})"
@@ -21,8 +21,6 @@ class ClearstreamHandler < ServiceHandlerBase
     return ReturnVo.new(value: return_accepted("clearstream_msg": msg), error: nil)
 
   rescue StandardError => e
-    puts '>> StandardError:'
-    puts e.to_s
     err_msg = self.get_err_msg(e)
     # Log Clearstream subscription warnings if necessary. Note Uhura does not submit create_subscriber requests.
     if err_msg&.include?('supplied subscribers is invalid') # "At least one of the supplied subscribers is invalid."

--- a/app/services/clearstream_handler.rb
+++ b/app/services/clearstream_handler.rb
@@ -63,7 +63,7 @@ class ClearstreamHandler < ServiceHandlerBase
     ReturnVo.new_err(err_msg)
   end
 
-  # Called from SendSendgridMessageWorker
+  # Called from ClearstreamMessageWorker
   def self.send_msg(data)
     # Request Clearstream client to send message
     response = ClearstreamClient::MessageClient.new(data: data,

--- a/app/services/clearstream_handler.rb
+++ b/app/services/clearstream_handler.rb
@@ -2,6 +2,88 @@
 
 class ClearstreamHandler < ServiceHandlerBase
   # rubocop:disable all
+
+  def self.send(message_vo)
+    # Populate attributes required for request
+    clearstream_vo = ClearstreamSmsVo.new(
+        receiver_sso_id: message_vo.receiver_sso_id,
+        team_name: message_vo.team_name,
+        sms_message: message_vo.sms_message,
+        message_id: message_vo.message_id
+    ).get
+
+    ClearstreamHandler.send_msg(clearstream_vo) # <= Uncomment to test synchronously
+    #ClearstreamMessageWorker.perform_async(clearstream_vo)
+
+    msg = "Asynchronously sent SMS: (#{message_vo.team_name}:#{message_vo.email_subject}) "
+    msg += "from (#{message_vo.manager_name}) to (#{message_vo.mobile_number})"
+    log_info(msg)
+    return ReturnVo.new(value: return_accepted("clearstream_msg": msg), error: nil)
+
+  rescue StandardError => e
+    puts '>> StandardError:'
+    puts e.to_s
+    err_msg = self.get_err_msg(e)
+    # Log Clearstream subscription warnings if necessary. Note Uhura does not submit create_subscriber requests.
+    if err_msg&.include?('supplied subscribers is invalid') # "At least one of the supplied subscribers is invalid."
+      # If the subscriber is invalid, let's assume that they've not been registered with Clearstream.io
+      # So, an entity outside of Uhura should create the subscriber see that they opt in before returning to Uhura.
+      action_msg = {
+          "error_from_clearstream": err_msg,
+          "assumed_meaning": "This receiver w/ mobile_number (#{message_vo.mobile_number}) not registered in Clearstream",
+          "action": "Research whether receiver_sso_id (#{message_vo.receiver_sso_id}) is valid."
+      }
+      log_warn(action_msg)
+      err_msg = {
+          "msg": err_msg,
+          "action_required:": action_msg
+      }
+    elsif err_msg&.include?('You must send your message to at least one subscriber')
+      # Since Uhura does not submit subscription requests, this block should never be executed
+      action_msg = {
+          "error_from_clearstream": err_msg,
+          "action": "Research status of Clearstream subscription for receiver_sso_id (#{message_vo.receiver_sso_id})"
+      }
+      log_warn(action_msg)
+      err_msg = {
+          "msg": err_msg,
+          "action_required:": action_msg
+      }
+    end
+    log_error(err_msg)
+    # A error occurs while processing the request. Record ERROR status.
+    clearstream_msg = ClearstreamMsg.create!(
+        response: {
+            error: err_msg
+        },
+        status: 'ERROR'
+    )
+    # Link clearstream_msg to message
+    message = Message.find(message_vo.message_id)
+    message.clearstream_msg = clearstream_msg
+    message.save!
+    ReturnVo.new_err(err_msg)
+  end
+
+  # Called from SendSendgridMessageWorker
+  def self.send_msg(data)
+    # Request Clearstream client to send message
+    response = ClearstreamClient::MessageClient.new(data: data,
+                                                    resource: 'messages').send_message
+    # Record Clearstream response
+    clearstream_msg = ClearstreamMsg.create!(sent_to_clearstream: Time.now,
+                                             response: response['data'] )
+    clearstream_msg.got_response_at = Time.now
+    clearstream_msg.status = response['data']['status']
+    clearstream_msg.clearstream_id = response['data']['id'] # <= Use clearstream_id as correlation id in webhook
+
+    if clearstream_msg.save! && link_clearstream_msg_to_message(data[:message_id], clearstream_msg.id)
+      return ReturnVo.new_value({clearstream_msg: clearstream_msg})
+    else
+      return ReturnVo.new_err(clearstream_msg.errors || "Error for clearstream_id (#{clearstream_id})")
+    end
+  end
+
   def self.link_clearstream_msg_to_message(message_id, clearstream_msg_id)
     clearstream_msg = ClearstreamMsg.find_by(id: clearstream_msg_id)
     if clearstream_msg.nil?
@@ -17,82 +99,5 @@ class ClearstreamHandler < ServiceHandlerBase
     message.save!
   end
 
-  def self.send_msg(data)
-    # Request Clearstream client to send message
-    response = ClearstreamClient::MessageClient.new(data: data[:clearstream_vo],
-                                                    resource: 'messages').send_message
-    # Record Clearstream response
-    # FIXME: We need to get the message id from clearsteam and save it here
-    # and when we look up for the message in the webhook we look for it.
-    clearstream_msg = ClearstreamMsg.create!(sent_to_clearstream: Time.now,
-                                             response: response['data'] )
-    clearstream_msg.got_response_at = Time.now
-    clearstream_msg.status = response['data']['status']
-
-    if clearstream_msg.save! && link_clearstream_msg_to_message(data[:message_id], clearstream_msg.id)
-      return ReturnVo.new_value({clearstream_msg: clearstream_msg})
-    else
-      return ReturnVo.new_err(clearstream_msg.errors || "Error for clearstream_id (#{clearstream_id})")
-    end
-  end
-
-  def self.send(message_vo)
-    # Populate attributes required for request
-    clearstream_vo = ClearstreamSmsVo.new(
-      receiver_sso_id: message_vo.receiver_sso_id,
-      team_name: message_vo.team_name,
-      sms_message: message_vo.sms_message,
-      message_id: message_vo.message_id
-    ).get
-
-    ClearstreamMessageWorker.perform_async(clearstream_vo)
-
-    msg = "Asynchronously sent SMS: (#{message_vo.team_name}:#{message_vo.email_subject}) "
-    msg += "from (#{message_vo.manager_name}) to (#{message_vo.mobile_number})"
-    log_info(msg)
-    return ReturnVo.new(value: return_accepted("clearstream_msg": msg), error: nil)
-
-  rescue StandardError => e
-    err_msg = self.get_err_msg(e)
-    # Log Clearstream subscription warnings if necessary. Note Uhura does not submit create_subscriber requests.
-    if err_msg&.include?('supplied subscribers is invalid') # "At least one of the supplied subscribers is invalid."
-      # If the subscriber is invalid, let's assume that they've not been registered with Clearstream.io
-      # So, an entity outside of Uhura should create the subscriber see that they opt in before returning to Uhura.
-      action_msg = {
-        "error_from_clearstream": err_msg,
-        "assumed_meaning": "This receiver w/ mobile_number (#{message_vo.mobile_number}) not registered in Clearstream",
-        "action": "Research whether receiver_sso_id (#{message_vo.receiver_sso_id}) is valid."
-      }
-      log_warn(action_msg)
-      err_msg = {
-        "msg": err_msg,
-        "action_required:": action_msg
-      }
-    elsif err_msg&.include?('You must send your message to at least one subscriber')
-      # Since Uhura does not submit subscription requests, this block should never be executed
-      action_msg = {
-        "error_from_clearstream": err_msg,
-        "action": "Research status of Clearstream subscription for receiver_sso_id (#{message_vo.receiver_sso_id})"
-      }
-      log_warn(action_msg)
-      err_msg = {
-        "msg": err_msg,
-        "action_required:": action_msg
-      }
-    end
-    log_error(err_msg)
-    # A error occurs while processing the request. Record ERROR status.
-    clearstream_msg = ClearstreamMsg.create!(
-        response: {
-          error: err_msg
-        },
-        status: 'ERROR'
-    )
-    # Link clearstream_msg to message
-    message = Message.find(message_vo.message_id)
-    message.clearstream_msg = clearstream_msg
-    message.save!
-    ReturnVo.new_err(err_msg)
-  end
 end
 # rubocop:enable all

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -8,7 +8,7 @@ class SendgridHandler < ServiceHandlerBase
     sendgrid_vo = create_sendgrid_msg(message_vo, template_data)
 
     # SendgridHandler.send_msg(sendgrid_vo) # <= Uncomment to test synchronously
-    SendSendgridMessageWorker.perform_async(sendgrid_vo)
+    SendgridMessageWorker.perform_async(sendgrid_vo)
 
     msg = "Asynchronously sent Email: (#{message_vo.team_name}:#{message_vo.email_subject}) "
     msg += "from (#{message_vo.manager_name}) to (#{message_vo.email} <#{message_vo.first} #{message_vo.last}>)"
@@ -51,7 +51,7 @@ class SendgridHandler < ServiceHandlerBase
     ReturnVo.new_err(err_msg)
   end
 
-  # Called from SendSendgridMessageWorker
+  # Called from SendgridMessageWorker
   def self.send_msg(sendgrid_vo)
     sendgrid_vo = deep_symbolize_keys_if_needed(sendgrid_vo)
     message_id = sendgrid_vo[:message_id]

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -7,8 +7,8 @@ class SendgridHandler < ServiceHandlerBase
 
     sendgrid_vo = create_sendgrid_msg(message_vo, template_data)
 
-    SendgridHandler.send_msg(sendgrid_vo) # <= Uncomment to test synchronously
-    # SendSendgridMessageWorker.perform_async(sendgrid_vo)
+    # SendgridHandler.send_msg(sendgrid_vo) # <= Uncomment to test synchronously
+    SendSendgridMessageWorker.perform_async(sendgrid_vo)
 
     msg = "Asynchronously sent Email: (#{message_vo.team_name}:#{message_vo.email_subject}) "
     msg += "from (#{message_vo.manager_name}) to (#{message_vo.email} <#{message_vo.first} #{message_vo.last}>)"

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -1,32 +1,77 @@
 # frozen_string_literal: true
 
 class SendgridHandler < ServiceHandlerBase
-  def self.link_sendgrid_msg_to_message(message_id, sendgrid_msg_id)
-    sendgrid_msg = SendgridMsg.find_by(id: sendgrid_msg_id)
-    if sendgrid_msg.nil?
-      log_error("Unable to find sendgrid_msg (#{sendgrid_msg_id}). Did not link message (#{message_id})")
-      return false
-    end
-    message = Message.find_by(id: message_id)
-    if message.nil?
-      log_error("Unable to find message (#{message_id}). Did not link sendgrid_msg (#{sendgrid_msg_id})")
-      return false
-    end
-    message.sendgrid_msg_id = sendgrid_msg_id
-    message.save!
+
+  def self.send(message_vo)
+    template_data = message_vo.email_message
+    template_data['email_subject'] = message_vo.email_subject
+
+    sendgrid_vo = create_sendgrid_msg(message_vo, template_data)
+
+    SendgridHandler.send_msg(sendgrid_vo) # <= Uncomment to test synchronously
+    #SendSendgridMessageWorker.perform_async(sendgrid_vo)
+
+    msg = "Asynchronously sent Email: (#{message_vo.team_name}:#{message_vo.email_subject}) "
+    msg += "from (#{message_vo.manager_name}) to (#{message_vo.email} <#{message_vo.first} #{message_vo.last}>)"
+    log_info(msg)
+    ReturnVo.new(value: return_accepted(sendgrid_msg: msg), error: nil)
+  rescue StandardError => e
+    err_msg = get_err_msg(e)
+    handle_sendgrid_msg_error(err_msg, sendgrid_vo, message_vo)
   end
 
+  def self.create_sendgrid_msg(message_vo, template_data)
+    sendgrid_msg_on_uhura = SendgridMsg.create
+    SendgridMailVo.new(
+      from: message_vo.manager_email,
+      subject: message_vo.email_subject,
+      receiver_sso_id: message_vo.receiver_sso_id,
+      template_id: message_vo.sendgrid_template_id,
+      dynamic_template_data: template_data,
+      email_options: message_vo.email_options,
+      personalizations: [
+        {
+          custom_args: { uhura_msg_id: sendgrid_msg_on_uhura.id }
+        }
+      ],
+      message_id: message_vo.message_id
+    ).vo
+  end
+
+  def self.handle_sendgrid_msg_error(err_msg, sendgrid_vo, message_vo)
+    # A error occurs while processing the request. Record ERROR status.
+    sendgrid_msg = SendgridMsg.create!(
+        mail_and_response: { mail: sendgrid_vo[:mail].to_json, response: { error: err_msg } },
+        status: 'ERROR'
+    )
+    # Link sendgrid_msg to message
+    message = Message.find(message_vo.message_id)
+    message.sendgrid_msg = sendgrid_msg
+    message.save!
+    ReturnVo.new_err(err_msg)
+  end
+
+  # Called from SendSendgridMessageWorker
   def self.send_msg(sendgrid_vo)
     sendgrid_vo = deep_symbolize_keys_if_needed(sendgrid_vo)
     message_id = sendgrid_vo[:message_id]
     mail_obj = SendgridMailVo.mail(sendgrid_vo[:mail_vo])
 
-    sendgrid_msg = find_sendgrid_msg_and_update_it(mail_obj, sendgrid_vo)
+    sendgrid_msg = send_email_and_update_sendgrid_msg(mail_obj, sendgrid_vo)
 
-    link_message_record_to_sendgrid_msg_record_and_return_it(sendgrid_msg, message_id)
+    save_and_link_message(sendgrid_msg, message_id)
   end
 
-  def self.find_sendgrid_msg_and_update_it(mail_obj, sendgrid_vo)
+  def self.deep_symbolize_keys_if_needed(sendgrid_vo)
+    if sendgrid_vo[:mail_vo].blank?
+      log_warn('Sidekiq performs a deep_stringify_keys on the hash; reverse that with deep_symbolize_keys.')
+      sendgrid_vo.deep_symbolize_keys
+    else
+      sendgrid_vo
+    end
+  end
+
+  def self.send_email_and_update_sendgrid_msg(mail_obj, sendgrid_vo)
     # Request Clearstream client to send message
     sent_to_sendgrid_at = Time.now
     response_and_mail = SendgridMailer.new.send_email(mail_obj)
@@ -44,70 +89,27 @@ class SendgridHandler < ServiceHandlerBase
     sendgrid_msg
   end
 
-  def self.deep_symbolize_keys_if_needed(sendgrid_vo)
-    if sendgrid_vo[:mail_vo].blank?
-      log_warn('Sidekiq performs a deep_stringify_keys on the hash; reverse that with deep_symbolize_keys.')
-      sendgrid_vo.deep_symbolize_keys
-    else
-      sendgrid_vo
-    end
-  end
-
-  def self.link_message_record_to_sendgrid_msg_record_and_return_it(sendgrid_msg, message_id)
+  def self.save_and_link_message(sendgrid_msg, message_id)
     # Link message record to sendgrid_msg record
     if sendgrid_msg.save! && link_sendgrid_msg_to_message(message_id, sendgrid_msg.id)
-      ReturnVo.new_value(sendgrid_msg: sendgrid_msg)
+      log_info("Successfully linked sendgrid_msg.id #{sendgrid_msg.id} to message_id #{message_id}")
     else
-      ReturnVo.new_err(sendgrid_msg.errors || "Error for sendgrid_id (#{sendgrid_id})")
+      log_error("Error linking sendgrid_msg.id #{sendgrid_msg.id} to message_id #{message_id} - #{sendgrid_msg.errors}")
     end
   end
 
-  def self.send(message_vo)
-    template_data = message_vo.email_message
-    template_data['email_subject'] = message_vo.email_subject
-
-    sendgrid_vo = populate_required_attributes_for_request(message_vo, template_data)
-
-    # SendgridHandler.send_msg(sendgrid_vo)
-    SendSendgridMessageWorker.perform_async(sendgrid_vo)
-
-    msg = "Asynchronously sent Email: (#{message_vo.team_name}:#{message_vo.email_subject}) "
-    msg += "from (#{message_vo.manager_name}) to (#{message_vo.email} <#{message_vo.first} #{message_vo.last}>)"
-    log_info(msg)
-    ReturnVo.new(value: return_accepted(sendgrid_msg: msg), error: nil)
-  rescue StandardError => e
-    err_msg = get_err_msg(e)
-    handle_sendgrid_msg_error(err_msg, sendgrid_vo, message_vo)
-  end
-
-  def self.handle_sendgrid_msg_error(err_msg, sendgrid_vo, message_vo)
-    # A error occurs while processing the request. Record ERROR status.
-    sendgrid_msg = SendgridMsg.create!(
-      mail_and_response: { mail: sendgrid_vo[:mail].to_json, response: { error: err_msg } },
-      status: 'ERROR'
-    )
-    # Link sendgrid_msg to message
-    message = Message.find(message_vo.message_id)
-    message.sendgrid_msg = sendgrid_msg
+  def self.link_sendgrid_msg_to_message(message_id, sendgrid_msg_id)
+    sendgrid_msg = SendgridMsg.find_by(id: sendgrid_msg_id)
+    if sendgrid_msg.nil?
+      log_error("Unable to find sendgrid_msg (#{sendgrid_msg_id}). Did not link message (#{message_id})")
+      return false
+    end
+    message = Message.find_by(id: message_id)
+    if message.nil?
+      log_error("Unable to find message (#{message_id}). Did not link sendgrid_msg (#{sendgrid_msg_id})")
+      return false
+    end
+    message.sendgrid_msg_id = sendgrid_msg_id
     message.save!
-    ReturnVo.new_err(err_msg)
-  end
-
-  def self.populate_required_attributes_for_request(message_vo, template_data)
-    sendgrid_msg_on_uhura = SendgridMsg.create
-    SendgridMailVo.new(
-      from: message_vo.manager_email,
-      subject: message_vo.email_subject,
-      receiver_sso_id: message_vo.receiver_sso_id,
-      template_id: message_vo.sendgrid_template_id,
-      dynamic_template_data: template_data,
-      email_options: message_vo.email_options,
-      personalizations: [
-        {
-          custom_args: { uhura_msg_id: sendgrid_msg_on_uhura.id }
-        }
-      ],
-      message_id: message_vo.message_id
-    ).vo
   end
 end

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -3,7 +3,7 @@
 class SendgridHandler < ServiceHandlerBase
   def self.send(message_vo)
     template_data = message_vo.email_message
-    template_data['email_subject'] = message_vo.email_subject
+    template_data['subject'] = message_vo.email_subject # Must use 'subject' for Sendgrid template
 
     sendgrid_vo = create_sendgrid_msg(message_vo, template_data)
 

--- a/app/services/sendgrid_handler.rb
+++ b/app/services/sendgrid_handler.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class SendgridHandler < ServiceHandlerBase
-
   def self.send(message_vo)
     template_data = message_vo.email_message
     template_data['email_subject'] = message_vo.email_subject
@@ -9,7 +8,7 @@ class SendgridHandler < ServiceHandlerBase
     sendgrid_vo = create_sendgrid_msg(message_vo, template_data)
 
     SendgridHandler.send_msg(sendgrid_vo) # <= Uncomment to test synchronously
-    #SendSendgridMessageWorker.perform_async(sendgrid_vo)
+    # SendSendgridMessageWorker.perform_async(sendgrid_vo)
 
     msg = "Asynchronously sent Email: (#{message_vo.team_name}:#{message_vo.email_subject}) "
     msg += "from (#{message_vo.manager_name}) to (#{message_vo.email} <#{message_vo.first} #{message_vo.last}>)"
@@ -41,8 +40,9 @@ class SendgridHandler < ServiceHandlerBase
   def self.handle_sendgrid_msg_error(err_msg, sendgrid_vo, message_vo)
     # A error occurs while processing the request. Record ERROR status.
     sendgrid_msg = SendgridMsg.create!(
-        mail_and_response: { mail: sendgrid_vo[:mail].to_json, response: { error: err_msg } },
-        status: 'ERROR'
+      mail_and_response: { mail: sendgrid_vo[:mail].to_json,
+                           response: { error: err_msg } },
+      status: 'ERROR'
     )
     # Link sendgrid_msg to message
     message = Message.find(message_vo.message_id)

--- a/app/workers/sendgrid_message_worker.rb
+++ b/app/workers/sendgrid_message_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SendSendgridMessageWorker
+class SendgridMessageWorker
   include Sidekiq::Worker
   sidekiq_options retry: false
 

--- a/app/workers/update_clearstream_msg_status_from_webhook_worker.rb
+++ b/app/workers/update_clearstream_msg_status_from_webhook_worker.rb
@@ -3,8 +3,8 @@
 class UpdateClearstreamMsgStatusFromWebhookWorker
   include Sidekiq::Worker
 
-  def perform(clearstream_msg_id, status)
-    clearstream_msg = ClearstreamMsg.find(clearstream_msg_id)
+  def perform(clearstream_id, status)
+    clearstream_msg = ClearstreamMsg.find_by(clearstream_id: clearstream_id)
     clearstream_msg.status = status
     clearstream_msg.save!
   end

--- a/app/workers/update_sendgrid_msg_status_from_webhook_worker.rb
+++ b/app/workers/update_sendgrid_msg_status_from_webhook_worker.rb
@@ -4,7 +4,6 @@ class UpdateSendgridMsgStatusFromWebhookWorker
   include Sidekiq::Worker
 
   def perform(message_id, status)
-    puts "\n\n>> UpdateSendgridMsgStatusFromWebhookWorker.perform = message_id: #{message_id}, status: #{status}\n\n"
     sendgrid_msg = SendgridMsg.find(message_id)
     if sendgrid_msg
       sendgrid_msg.status = status

--- a/app/workers/update_sendgrid_msg_status_from_webhook_worker.rb
+++ b/app/workers/update_sendgrid_msg_status_from_webhook_worker.rb
@@ -4,8 +4,8 @@ class UpdateSendgridMsgStatusFromWebhookWorker
   include Sidekiq::Worker
 
   def perform(message_id, status)
+    puts "\n\n>> UpdateSendgridMsgStatusFromWebhookWorker.perform = message_id: #{message_id}, status: #{status}\n\n"
     sendgrid_msg = SendgridMsg.find(message_id)
-
     if sendgrid_msg
       sendgrid_msg.status = status
       sendgrid_msg.save!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,4 +79,7 @@ class Object
       self.public_methods.sort - Object.new.public_methods
     end
   end
+  def interesting_methods_filter(where)
+    self.interesting_methods.select {|i| i.to_s =~ /#{where}/ }
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,6 +79,7 @@ class Object
       self.public_methods.sort - Object.new.public_methods
     end
   end
+  # Return methods whose name matches where string.  Ex: User.new.interesting_methods_filter('first')
   def interesting_methods_filter(where)
     self.interesting_methods.select {|i| i.to_s =~ /#{where}/ }
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,3 +4,8 @@ Sidekiq.configure_server do |config|
   Rails.logger = Sidekiq::Logging.logger
   ActiveRecord::Base.logger = Sidekiq::Logging.logger
 end
+
+if Rails.env.development? || Rails.env.test?
+  require 'sidekiq/testing'
+  Sidekiq::Testing.inline!
+end

--- a/db/migrate/20190509014847_create_clearstream_msgs.rb
+++ b/db/migrate/20190509014847_create_clearstream_msgs.rb
@@ -5,6 +5,7 @@ class CreateClearstreamMsgs < ActiveRecord::Migration[6.0]
       t.json :response
       t.datetime :got_response_at
       t.text :status
+      t.integer :clearstream_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_05_12_215905) do
     t.json "response"
     t.datetime "got_response_at"
     t.text "status"
+    t.integer "clearstream_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,112 +72,112 @@ log! "6. Seeding MsgTarget"
 MsgTarget.create!(name: 'Sendgrid', description: 'External Email Service')
 MsgTarget.create!(name: 'Clearstream', description: 'External SMS Texting Service')
 
-log! "7. Seeding Messages"
-msg1 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
-                       manager_id: app1.id, # <= source (an application)
-                       team_id: leadership_team.id, # <= message coming from this team
-                       receiver_id: bob.id, # <= receiver (a user)
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_a.id,
-                       sms_message:  Faker::Movie.quote)
-
-msg2 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
-                       manager_id: app1.id,
-                       team_id: campus_pastor_team.id,
-                       receiver_id: bob.id,
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "section2": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_b.id,
-                       sms_message:  Faker::Movie.quote)
-
-msg3 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
-                       manager_id: app1.id,
-                       team_id: leadership_team.id,
-                       receiver_id: cindy.id,
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_a.id,
-                       sms_message:  Faker::Movie.quote)
-
-msg4 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
-                       manager_id: app2.id,
-                       team_id: leadership_team.id,
-                       receiver_id: alice.id, # <= receiver (a user)
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_a.id,
-                       sms_message:  Faker::Movie.quote)
-
-msg5 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
-                       manager_id: app2.id,
-                       team_id: campus_pastor_team.id,
-                       receiver_id: bob.id, # <= receiver (a user)
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "section2": Faker::Quote.matz,
-                           "section3": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_c.id,
-                       sms_message:  Faker::Movie.quote)
-
-msg6 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
-                       manager_id: app2.id,
-                       team_id: leadership_team.id,
-                       receiver_id: cindy.id, # <= receiver (a user)
-                       email_subject: Faker::TvShows::SiliconValley.motto,
-                       email_message:  {
-                           "header": Faker::Games::Pokemon.move.titleize,
-                           "section1": Faker::Quote.matz,
-                           "button": Faker::Verb.base.capitalize
-                       },
-                       template_id: template_a.id,
-                       sms_message:  Faker::Movie.quote)
-
-log! "8. Seeding SendgridMsg and ClearstreamMsg"
-sg1 = SendgridMsg.create!(sent_to_sendgrid: Time.now, read_by_user_at: 1.day.from_now)
-msg1.sendgrid_msg = sg1
-msg1.save!
-
-sg2 = SendgridMsg.create!(sent_to_sendgrid: 1.minute.from_now, read_by_user_at: 2.days.from_now)
-msg2.sendgrid_msg = sg2
-msg2.save!
-
-cs1 = ClearstreamMsg.create!(sent_to_clearstream: 2.minutes.from_now)
-msg3.clearstream_msg = cs1
-msg3.save!
-
-cs2 = ClearstreamMsg.create!(sent_to_clearstream: 4.minutes.from_now)
-msg4.clearstream_msg = cs2
-msg4.save!
-
-sg3 = SendgridMsg.create!(sent_to_sendgrid: 5.minutes.from_now, read_by_user_at: 3.days.from_now)
-msg5.sendgrid_msg = sg3
-msg5.save!
-
-cs3 = ClearstreamMsg.create!(sent_to_clearstream: 7.minutes.from_now)
-msg6.clearstream_msg = cs3
-msg6.save!
+# log! "7. Seeding Messages"
+# msg1 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
+#                        manager_id: app1.id, # <= source (an application)
+#                        team_id: leadership_team.id, # <= message coming from this team
+#                        receiver_id: bob.id, # <= receiver (a user)
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_a.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# msg2 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
+#                        manager_id: app1.id,
+#                        team_id: campus_pastor_team.id,
+#                        receiver_id: bob.id,
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "section2": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_b.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# msg3 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
+#                        manager_id: app1.id,
+#                        team_id: leadership_team.id,
+#                        receiver_id: cindy.id,
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_a.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# msg4 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
+#                        manager_id: app2.id,
+#                        team_id: leadership_team.id,
+#                        receiver_id: alice.id, # <= receiver (a user)
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_a.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# msg5 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Sendgrid').id,
+#                        manager_id: app2.id,
+#                        team_id: campus_pastor_team.id,
+#                        receiver_id: bob.id, # <= receiver (a user)
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "section2": Faker::Quote.matz,
+#                            "section3": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_c.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# msg6 = Message.create!(msg_target_id: MsgTarget.find_by(name: 'Clearstream').id,
+#                        manager_id: app2.id,
+#                        team_id: leadership_team.id,
+#                        receiver_id: cindy.id, # <= receiver (a user)
+#                        email_subject: Faker::TvShows::SiliconValley.motto,
+#                        email_message:  {
+#                            "header": Faker::Games::Pokemon.move.titleize,
+#                            "section1": Faker::Quote.matz,
+#                            "button": Faker::Verb.base.capitalize
+#                        },
+#                        template_id: template_a.id,
+#                        sms_message:  Faker::Movie.quote)
+#
+# log! "8. Seeding SendgridMsg and ClearstreamMsg"
+# sg1 = SendgridMsg.create!(sent_to_sendgrid: Time.now, read_by_user_at: 1.day.from_now)
+# msg1.sendgrid_msg = sg1
+# msg1.save!
+#
+# sg2 = SendgridMsg.create!(sent_to_sendgrid: 1.minute.from_now, read_by_user_at: 2.days.from_now)
+# msg2.sendgrid_msg = sg2
+# msg2.save!
+#
+# cs1 = ClearstreamMsg.create!(sent_to_clearstream: 2.minutes.from_now)
+# msg3.clearstream_msg = cs1
+# msg3.save!
+#
+# cs2 = ClearstreamMsg.create!(sent_to_clearstream: 4.minutes.from_now)
+# msg4.clearstream_msg = cs2
+# msg4.save!
+#
+# sg3 = SendgridMsg.create!(sent_to_sendgrid: 5.minutes.from_now, read_by_user_at: 3.days.from_now)
+# msg5.sendgrid_msg = sg3
+# msg5.save!
+#
+# cs3 = ClearstreamMsg.create!(sent_to_clearstream: 7.minutes.from_now)
+# msg6.clearstream_msg = cs3
+# msg6.save!
 
 log! 'Seeding Done!'
 log! "public_token: #{Manager.first.public_token}"

--- a/spec/controllers/api/v1/messages_spec.rb
+++ b/spec/controllers/api/v1/messages_spec.rb
@@ -326,21 +326,21 @@ RSpec.describe 'Messages API', type: :request do
       let(:receiver) { Receiver.find_by(first_name: 'Bob'); }
       let(:valid_attributes) do
         {
-            "public_token": manager.public_token,
-            "receiver_sso_id": receiver.receiver_sso_id,
-            "email_subject": 'Picnic Saturday',
-            "email_message": {
-                "header": 'Dragon Rage',
-                "button": 'Count me in!'
-            },
-            "template_id": 'd-f986df533e514f978f4460bedca50db0',
-            "sms_message": 'Bring Drinks to the Picnic this Saturday'
+          "public_token": manager.public_token,
+          "receiver_sso_id": receiver.receiver_sso_id,
+          "email_subject": 'Picnic Saturday',
+          "email_message": {
+            "header": 'Dragon Rage',
+            "button": 'Count me in!'
+          },
+          "template_id": 'd-f986df533e514f978f4460bedca50db0',
+          "sms_message": 'Bring Drinks to the Picnic this Saturday'
         }
       end
       it 'returns status code 422' do
         stub_request(:any, /api.sendgrid.com/)
-            .to_return(body: get_sendgrid_response_data('post_message_0_sections'),
-                       status: 422)
+          .to_return(body: get_sendgrid_response_data('post_message_0_sections'),
+                     status: 422)
         expect do
           post('/api/v1/messages',
                headers: valid_headers,
@@ -354,21 +354,21 @@ RSpec.describe 'Messages API', type: :request do
     let(:receiver) { Receiver.find_by(first_name: 'Bob'); }
     let(:valid_attributes) do
       {
-          "public_token": manager.public_token,
-          "receiver_sso_id": receiver.receiver_sso_id,
-          "email_subject": 'Picnic Saturday',
-          "email_message": {
-              "header": 'Dragon Rage',
-              "button": 'Count me in!'
-          },
-          "template_id": 'XXX-f986df533e514f978f4460bedca50db0',
-          "sms_message": 'Bring Drinks to the Picnic this Saturday'
+        "public_token": manager.public_token,
+        "receiver_sso_id": receiver.receiver_sso_id,
+        "email_subject": 'Picnic Saturday',
+        "email_message": {
+          "header": 'Dragon Rage',
+          "button": 'Count me in!'
+        },
+        "template_id": 'XXX-f986df533e514f978f4460bedca50db0',
+        "sms_message": 'Bring Drinks to the Picnic this Saturday'
       }
     end
     it 'returns status code 422' do
       stub_request(:any, /api.sendgrid.com/)
-          .to_return(body: get_sendgrid_response_data('invalid_template_id'),
-                     status: 422)
+        .to_return(body: get_sendgrid_response_data('invalid_template_id'),
+                   status: 422)
       expect do
         post('/api/v1/messages',
              headers: valid_headers,

--- a/spec/controllers/api/v1/messages_spec.rb
+++ b/spec/controllers/api/v1/messages_spec.rb
@@ -193,7 +193,6 @@ RSpec.describe 'Messages API', type: :request do
         stub_request(:any, /api.sendgrid.com/)
           .to_return(body: get_sendgrid_response_data('post_message'),
                      status: 200)
-
         post '/api/v1/messages', headers: valid_headers, params: valid_attributes.to_json
         # Just created 3rd message.
         link_to_sendgrid

--- a/spec/controllers/api/v1/web_hooks_controller_spec.rb
+++ b/spec/controllers/api/v1/web_hooks_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Web Hooks', type: :request do
     describe 'POST /api/v1/web_hooks/clearstream' do
       it 'returns status code 200' do
         create(:clearstream_msg, clearstream_id: 128_582)
-        get_clearstream_response_data
+        stub_request(:any, /api.getclearstream.com/)
           .to_return(body: get_clearstream_response_data('webhook_params'),
                      status: 200)
 

--- a/spec/controllers/api/v1/web_hooks_controller_spec.rb
+++ b/spec/controllers/api/v1/web_hooks_controller_spec.rb
@@ -44,43 +44,17 @@ RSpec.describe 'Web Hooks', type: :request do
 
   context 'when CLEARSTREAM' do
     let(:clearstream_data) do
-      {
-        "created_at": '2019-01-01T10:02:00Z',
-        "event": 'message.report',
-        "data": {
-          "message": {
-            "id": 1_249_380,
-            "status": 'SENT',
-            "sent_at": '2019-01-01T09:30:00Z',
-            "completed_at": '2019-01-01T09:32:00Z',
-            "text": {
-              "full": 'Blue Sushi: We have a really great weekend coming up! Stay tuned!',
-              "header": 'Blue Sushi',
-              "body": 'We have a really great weekend coming up! Stay tuned!'
-            },
-            "lists": [
-              {
-                "id": 193_029,
-                "name": 'Master List'
-              }
-            ],
-            "subscribers": [],
-            "stats": {
-              "recipients": 5300,
-              "failures": 15,
-              "replies": 22,
-              "opt_outs": 19
-            }
-          }
-        }
-      }
+      get_clearstream_response_data('webhook_body')
     end
 
-    describe 'POST /api/v1/web_hooks/sendgrid' do
+    describe 'POST /api/v1/web_hooks/clearstream' do
       it 'returns status code 200' do
-        create(:clearstream_msg, id: '1249380')
-        post '/api/v1/web_hooks/clearstream', params: clearstream_data.to_json, headers: { "Content-Type": 'application/json' }
+        create(:clearstream_msg, clearstream_id: 128_582)
+        get_clearstream_response_data
+          .to_return(body: get_clearstream_response_data('webhook_params'),
+                     status: 200)
 
+        post '/api/v1/web_hooks/clearstream', params: clearstream_data, headers: { "Content-Type": 'application/json' }
         expect(response.status).to eq 204
         expect(ClearstreamMsg.first.status).to eq 'SENT'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'sidekiq/testing/inline'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 FIXTURE_DIR = "#{__dir__}/support/fixtures"

--- a/spec/support/fixtures/clearstream/webhook_body.json
+++ b/spec/support/fixtures/clearstream/webhook_body.json
@@ -1,0 +1,56 @@
+{
+  "created_at": "2019-07-03T02:28:01+00:00",
+  "event": "message.report",
+  "data": {
+    "message": {
+      "id": 128582,
+      "status": "SENT",
+      "sent_at": "2019-07-03T01:56:49+00:00",
+      "completed_at": "2019-07-03T01:56:50+00:00",
+      "text": {
+        "full": "Leadership Team: Come in now for 50% off all rolls!",
+        "header": "Leadership Team",
+        "body": "Come in now for 50% off all rolls!"
+      },
+      "lists": [],
+      "subscribers": [
+        "+17707651573"
+      ],
+      "stats": {
+        "recipients": 1,
+        "failures": 0,
+        "replies": 0,
+        "opt_outs": 0
+      }
+    }
+  },
+  "controller": "api/v1/web_hooks",
+  "action": "clearstream",
+  "web_hook": {
+    "created_at": "2019-07-03T02:28:01+00:00",
+    "event": "message.report",
+    "data": {
+      "message": {
+        "id": 128582,
+        "status": "SENT",
+        "sent_at": "2019-07-03T01:56:49+00:00",
+        "completed_at": "2019-07-03T01:56:50+00:00",
+        "text": {
+          "full": "Leadership Team: Come in now for 50% off all rolls!",
+          "header": "Leadership Team",
+          "body": "Come in now for 50% off all rolls!"
+        },
+        "lists": [],
+        "subscribers": [
+          "+17707651573"
+        ],
+        "stats": {
+          "recipients": 1,
+          "failures": 0,
+          "replies": 0,
+          "opt_outs": 0
+        }
+      }
+    }
+  }
+}

--- a/spec/support/fixtures/clearstream/webhook_params.json
+++ b/spec/support/fixtures/clearstream/webhook_params.json
@@ -1,0 +1,21 @@
+{
+  "id": 128695,
+  "status": "SENT",
+  "sent_at": "2019-07-03T15:31:11+00:00",
+  "completed_at": "2019-07-03T15:31:12+00:00",
+  "text": {
+    "full": "Leadership Team: Come in now for 50% off all rolls!",
+    "header": "Leadership Team",
+    "body": "Come in now for 50% off all rolls!"
+  },
+  "lists": [],
+  "subscribers": [
+    "+17707651573"
+  ],
+  "stats": {
+    "recipients": 1,
+    "failures": 0,
+    "replies": 0,
+    "opt_outs": 0
+  }
+}

--- a/spec/support/fixtures/sendgrid/invalid_template_id.json
+++ b/spec/support/fixtures/sendgrid/invalid_template_id.json
@@ -1,0 +1,65 @@
+{
+  "status": 200,
+  "data": {
+    "id": 19,
+    "msg_target_id": 1,
+    "manager_id": 1,
+    "receiver_id": 3,
+    "team_id": 1,
+    "email_subject": "Picnic Saturday",
+    "email_message": "{\"header\"=>\"Dragon Rage\", \"section1\"=>\"imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.\", \"button\"=>\"Count me in!\"}",
+    "email_options": null,
+    "template_id": 0,
+    "sms_message": "Bring Drinks to the Picnic this Saturday",
+    "message_params": {
+      "public_token": "42c50c442ee3ca01378e",
+      "receiver_sso_id": "55357450",
+      "email_subject": "Picnic Saturday",
+      "email_message": {
+        "header": "Dragon Rage",
+        "section1": "imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.",
+        "button": "Count me in!"
+      },
+      "email_options": null,
+      "template_id": "XXX-f986df533e514f978f4460bedca50db0",
+      "sms_message": "Bring Drinks to the Picnic this Saturday"
+    },
+    "message_attrs": {
+      "errors": [
+        "Template ID (XXX-f986df533e514f978f4460bedca50db0) not found. If it is valid, add it via the Admin application."
+      ],
+      "public_token": "42c50c442ee3ca01378e",
+      "receiver_sso_id": "55357450",
+      "email_subject": "Picnic Saturday",
+      "email_message": {
+        "header": "Dragon Rage",
+        "section1": "imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.",
+        "button": "Count me in!"
+      },
+      "email_options": null,
+      "template_id": "XXX-f986df533e514f978f4460bedca50db0",
+      "sms_message": "Bring Drinks to the Picnic this Saturday",
+      "manager_id": 1,
+      "manager_name": "Sample - App 1",
+      "manager_email": "app1@highlands.org",
+      "team_name": "Leadership Team",
+      "receiver_id": 3,
+      "mobile_number": "?+!42",
+      "first": "Cindy",
+      "last": "Red",
+      "email": "cindy.smyth@protonmail.com",
+      "lists": "25057",
+      "receiver_preferences": {
+        "email": true,
+        "sms": false
+      },
+      "msg_target_id": 1,
+      "team_id": 1,
+      "sendgrid_template_id": "XXX-f986df533e514f978f4460bedca50db0",
+      "validation_context": null
+    },
+    "created_at": "2019-07-06T15:53:53.313Z",
+    "updated_at": "2019-07-06T15:53:53.313Z"
+  },
+  "error": null
+}

--- a/spec/support/fixtures/sendgrid/webhook_params.json
+++ b/spec/support/fixtures/sendgrid/webhook_params.json
@@ -1,0 +1,58 @@
+{
+  "_json": [
+    {
+      "email": "cindy@example.com",
+      "event": "processed",
+      "sg_event_id": "cHJvY2Vzc2VkLTExMDMwNTgyLUVOLXJJVk12UWlLSFFXYkhULUY0ZFEtMA",
+      "sg_message_id": "EN-rIVMvQiKHQWbHT-F4dQ.filter0082p3las1-14721-5D18BC22-34.0",
+      "sg_template_id": "d-05d33214e6994b01b577602036bfa9f5",
+      "sg_template_name": "Untitled_11560898350188",
+      "smtp-id": "\u003cEN-rIVMvQiKHQWbHT-F4dQ@ismtpd0019p1iad2.sendgrid.net\u003e",
+      "timestamp": 1561902115,
+      "uhura_msg_id": "e7664350-e791-4c4f-a78e-d68f1f924c2b"
+    },
+    {
+      "email": "cindy@example.com",
+      "event": "delivered",
+      "ip": "167.89.106.62",
+      "response": "250 2.0.0 Ok: queued as 7ED587A7",
+      "sg_event_id": "ZGVsaXZlcmVkLTAtMTEwMzA1ODItRU4tcklWTXZRaUtIUVdiSFQtRjRkUS0w",
+      "sg_message_id": "EN-rIVMvQiKHQWbHT-F4dQ.filter0082p3las1-14721-5D18BC22-34.0",
+      "sg_template_id": "d-05d33214e6994b01b577602036bfa9f5",
+      "sg_template_name": "Untitled_11560898350188",
+      "smtp-id": "\u003cEN-rIVMvQiKHQWbHT-F4dQ@ismtpd0019p1iad2.sendgrid.net\u003e",
+      "timestamp": 1561902119,
+      "tls": 1,
+      "uhura_msg_id": "e7664350-e791-4c4f-a78e-d68f1f924c2b"
+    }
+  ],
+  "web_hook": {
+    "_json": [
+      {
+        "email": "cindy@example.com",
+        "event": "processed",
+        "sg_event_id": "cHJvY2Vzc2VkLTExMDMwNTgyLUVOLXJJVk12UWlLSFFXYkhULUY0ZFEtMA",
+        "sg_message_id": "EN-rIVMvQiKHQWbHT-F4dQ.filter0082p3las1-14721-5D18BC22-34.0",
+        "sg_template_id": "d-05d33214e6994b01b577602036bfa9f5",
+        "sg_template_name": "Untitled_11560898350188",
+        "smtp-id": "\u003cEN-rIVMvQiKHQWbHT-F4dQ@ismtpd0019p1iad2.sendgrid.net\u003e",
+        "timestamp": 1561902115,
+        "uhura_msg_id": "e7664350-e791-4c4f-a78e-d68f1f924c2b"
+      },
+      {
+        "email": "cindy@example.com",
+        "event": "delivered",
+        "ip": "167.89.106.62",
+        "response": "250 2.0.0 Ok: queued as 7ED587A7",
+        "sg_event_id": "ZGVsaXZlcmVkLTAtMTEwMzA1ODItRU4tcklWTXZRaUtIUVdiSFQtRjRkUS0w",
+        "sg_message_id": "EN-rIVMvQiKHQWbHT-F4dQ.filter0082p3las1-14721-5D18BC22-34.0",
+        "sg_template_id": "d-05d33214e6994b01b577602036bfa9f5",
+        "sg_template_name": "Untitled_11560898350188",
+        "smtp-id": "\u003cEN-rIVMvQiKHQWbHT-F4dQ@ismtpd0019p1iad2.sendgrid.net\u003e",
+        "timestamp": 1561902119,
+        "tls": 1,
+        "uhura_msg_id": "e7664350-e791-4c4f-a78e-d68f1f924c2b"
+      }
+    ]
+  }
+}

--- a/spec/workers/clearstream_message_worker_spec.rb
+++ b/spec/workers/clearstream_message_worker_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ClearstreamMessageWorker do
           .to_raise(ClearstreamClient::BaseClient::APIError)
 
         expect do
-          Sidekiq::Testing.inline! { ClearstreamMessageWorker.perform_async(clearstream_vo) }
+          ClearstreamMessageWorker.perform_async(clearstream_vo)
         end.to raise_error(ClearstreamClient::BaseClient::APIError)
       end
     end

--- a/spec/workers/sendgrid_message_worker_spec.rb
+++ b/spec/workers/sendgrid_message_worker_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SendgridMessageWorker do
 
         expect do
           sendgrid_vo = nil
-          Sidekiq::Testing.inline! { SendgridMessageWorker.perform_async(sendgrid_vo) }
+          SendgridMessageWorker.perform_async(sendgrid_vo)
         end.to raise_error(NoMethodError)
       end
     end

--- a/spec/workers/sendgrid_message_worker_spec.rb
+++ b/spec/workers/sendgrid_message_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SendSendgridMessageWorker do
+RSpec.describe SendgridMessageWorker do
   before do
     Sidekiq::Worker.clear_all
   end
@@ -76,7 +76,7 @@ RSpec.describe SendSendgridMessageWorker do
 
         expect do
           sendgrid_vo = nil
-          Sidekiq::Testing.inline! { SendSendgridMessageWorker.perform_async(sendgrid_vo) }
+          Sidekiq::Testing.inline! { SendgridMessageWorker.perform_async(sendgrid_vo) }
         end.to raise_error(NoMethodError)
       end
     end

--- a/spec/workers/update_clearstream_msg_status_from_webhook_worker_spec.rb
+++ b/spec/workers/update_clearstream_msg_status_from_webhook_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UpdateClearstreamMsgStatusFromWebhookWorker, type: :worker do
   let!(:clearstream_msg) { create(:clearstream_msg, clearstream_id: 99_999) }
 
   it 'updates the clearstream msg we pass' do
-    Sidekiq::Testing.inline! { UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg.clearstream_id, 'open') }
+    UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg.clearstream_id, 'open')
     expect(ClearstreamMsg.first.status).to eq 'open'
   end
 end

--- a/spec/workers/update_clearstream_msg_status_from_webhook_worker_spec.rb
+++ b/spec/workers/update_clearstream_msg_status_from_webhook_worker_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 RSpec.describe UpdateClearstreamMsgStatusFromWebhookWorker, type: :worker do
-  let!(:msg) { create(:clearstream_msg) }
+  let!(:clearstream_msg) { create(:clearstream_msg, clearstream_id: 99_999) }
 
   it 'updates the clearstream msg we pass' do
-    Sidekiq::Testing.inline! { UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(msg.id, 'open') }
+    Sidekiq::Testing.inline! { UpdateClearstreamMsgStatusFromWebhookWorker.perform_async(clearstream_msg.clearstream_id, 'open') }
     expect(ClearstreamMsg.first.status).to eq 'open'
   end
 end

--- a/spec/workers/update_sendgrid_msg_status_from_webhook_worker_spec.rb
+++ b/spec/workers/update_sendgrid_msg_status_from_webhook_worker_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe UpdateSendgridMsgStatusFromWebhookWorker, type: :worker do
   let!(:msg) { create(:sendgrid_msg) }
 
   it 'updates the sendgrid msg we pass' do
-    Sidekiq::Testing.inline! { UpdateSendgridMsgStatusFromWebhookWorker.perform_async(msg.id, 'open') }
+    # Inline testing configured in intitializer: Sidekiq::Testing.inline!
+    UpdateSendgridMsgStatusFromWebhookWorker.perform_async(msg.id, 'open')
     expect(SendgridMsg.first.status).to eq 'open'
   end
 end


### PR DESCRIPTION
Sendgrid dynamic templates must only use "subject".  So, we can't use "email_subject".  Note that we can use any field name inside the email template itself.