### PR TITLE
Use consistent ID type for sendgrid_msg_event and clearstream_msg_event

### DIFF
--- a/db/migrate/20190509014843_create_sendgrid_msg_events.rb
+++ b/db/migrate/20190509014843_create_sendgrid_msg_events.rb
@@ -1,6 +1,6 @@
 class CreateSendgridMsgEvents < ActiveRecord::Migration[6.0]
   def change
-    create_table :sendgrid_msg_events, id: :uuid do |t|
+    create_table :sendgrid_msg_events do |t|
       t.references :sendgrid_msg, null: true, type: :uuid, foreign_key: true
       t.string :status
       t.json :event

--- a/db/migrate/20190509014848_create_clearstream_msg_events.rb
+++ b/db/migrate/20190509014848_create_clearstream_msg_events.rb
@@ -1,6 +1,5 @@
 class CreateClearstreamMsgEvents < ActiveRecord::Migration[6.0]
   def change
-    #create_table :clearstream_msg_events, id: :uuid do |t|
     create_table :clearstream_msg_events do |t|
       t.references :clearstream_msg, null: true, type: :uuid, foreign_key: true
       t.string :status

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2019_05_12_215905) do
     t.index ["receiver_sso_id"], name: "index_receivers_on_receiver_sso_id", unique: true
   end
 
-  create_table "sendgrid_msg_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "sendgrid_msg_events", force: :cascade do |t|
     t.uuid "sendgrid_msg_id"
     t.string "status"
     t.json "event"


### PR DESCRIPTION
Making ID type consistent (bigint) for sendgrid_msg_events and clearstream_msg_events tables