### PR TITLE
Display webhook callback event history in admin app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "haml-rails" #, "~> 2.0"
 gem 'font-awesome-sass', '~> 5.6', '>= 5.6.1'
 #gem 'administrate', github: 'thoughtbot/administrate'
 gem 'administrate', github: 'l3x/administrate'
+gem 'administrate-field-nested_has_many'
 gem 'slim'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
       zeitwerk (~> 2.1, >= 2.1.4)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    administrate-field-nested_has_many (1.1.0)
+      administrate (> 0.8, < 1)
+      cocoon (~> 1.2, >= 1.2.11)
     ast (2.4.0)
     autoprefixer-rails (9.5.1.1)
       execjs
@@ -107,6 +110,7 @@ GEM
     chartkick (3.2.0)
     childprocess (1.0.1)
       rake (< 13.0)
+    cocoon (1.2.14)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.5)
@@ -385,6 +389,7 @@ PLATFORMS
 
 DEPENDENCIES
   administrate!
+  administrate-field-nested_has_many
   awesome_print
   byebug
   capybara (>= 2.15)

--- a/app/controllers/site_admin/clearstream_msg_events_controller.rb
+++ b/app/controllers/site_admin/clearstream_msg_events_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SiteAdmin
+  class ClearstreamMsgEventsController < SiteAdmin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/site_admin/sendgrid_msg_events_controller.rb
+++ b/app/controllers/site_admin/sendgrid_msg_events_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SiteAdmin
+  class SendgridMsgEventsController < SiteAdmin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/clearstream_msg_dashboard.rb
+++ b/app/dashboards/clearstream_msg_dashboard.rb
@@ -10,11 +10,12 @@ class ClearstreamMsgDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::Number,
+    id: Field::String.with_options(searchable: false),
     sent_to_clearstream: Field::DateTime,
     response: Field::String.with_options(searchable: false),
     got_response_at: Field::DateTime,
     status: Field::Text,
+    clearstream_msg_events: Field::NestedHasMany.with_options(skip: :clearstream_msg),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -39,6 +40,7 @@ class ClearstreamMsgDashboard < Administrate::BaseDashboard
     response
     got_response_at
     status
+    clearstream_msg_events
     created_at
     updated_at
   ].freeze

--- a/app/dashboards/clearstream_msg_event_dashboard.rb
+++ b/app/dashboards/clearstream_msg_event_dashboard.rb
@@ -2,7 +2,7 @@
 
 require 'administrate/base_dashboard'
 
-class SendgridMsgDashboard < Administrate::BaseDashboard
+class ClearstreamMsgEventDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -10,13 +10,10 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::String.with_options(searchable: false),
-    sent_to_sendgrid: Field::DateTime,
-    mail_and_response: Field::String.with_options(searchable: false),
-    got_response_at: Field::DateTime,
-    sendgrid_response: Field::Text,
-    read_by_user_at: Field::DateTime,
-    sendgrid_msg_events: Field::NestedHasMany.with_options(skip: :sendgrid_msg),
+    clearstream_msg: Field::BelongsTo,
+    id: Field::Number,
+    status: Field::String,
+    event: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -27,22 +24,19 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
+    clearstream_msg
     id
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
+    status
+    event
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
+    clearstream_msg
     id
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
-    sendgrid_response
-    read_by_user_at
-    sendgrid_msg_events
+    status
+    event
     created_at
     updated_at
   ].freeze
@@ -51,17 +45,15 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
-    sendgrid_response
-    read_by_user_at
+    clearstream_msg
+    status
+    event
   ].freeze
 
-  # Overwrite this method to customize how sendgrid msgs are displayed
+  # Overwrite this method to customize how clearstream msg events are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(sendgrid_msg)
-  #   "SendgridMsg ##{sendgrid_msg.id}"
+  # def display_resource(clearstream_msg_event)
+  #   "ClearstreamMsgEvent ##{clearstream_msg_event.id}"
   # end
 end

--- a/app/dashboards/sendgrid_msg_event_dashboard.rb
+++ b/app/dashboards/sendgrid_msg_event_dashboard.rb
@@ -2,7 +2,7 @@
 
 require 'administrate/base_dashboard'
 
-class SendgridMsgDashboard < Administrate::BaseDashboard
+class SendgridMsgEventDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -10,13 +10,10 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::String.with_options(searchable: false),
-    sent_to_sendgrid: Field::DateTime,
-    mail_and_response: Field::String.with_options(searchable: false),
-    got_response_at: Field::DateTime,
-    sendgrid_response: Field::Text,
-    read_by_user_at: Field::DateTime,
-    sendgrid_msg_events: Field::NestedHasMany.with_options(skip: :sendgrid_msg),
+    sendgrid_msg: Field::BelongsTo,
+    id: Field::Number,
+    status: Field::String,
+    event: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -27,22 +24,19 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
+    sendgrid_msg
     id
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
+    status
+    event
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
+    sendgrid_msg
     id
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
-    sendgrid_response
-    read_by_user_at
-    sendgrid_msg_events
+    status
+    event
     created_at
     updated_at
   ].freeze
@@ -51,17 +45,15 @@ class SendgridMsgDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    sent_to_sendgrid
-    mail_and_response
-    got_response_at
-    sendgrid_response
-    read_by_user_at
+    sendgrid_msg
+    status
+    event
   ].freeze
 
-  # Overwrite this method to customize how sendgrid msgs are displayed
+  # Overwrite this method to customize how sendgrid msg events are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(sendgrid_msg)
-  #   "SendgridMsg ##{sendgrid_msg.id}"
+  # def display_resource(sendgrid_msg_event)
+  #   "SendgridMsgEvent ##{sendgrid_msg_event.id}"
   # end
 end

--- a/app/models/clearstream_msg.rb
+++ b/app/models/clearstream_msg.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ClearstreamMsg < ApplicationRecord
+  has_many :clearstream_msg_events
 end

--- a/app/models/sendgrid_msg.rb
+++ b/app/models/sendgrid_msg.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SendgridMsg < ApplicationRecord
+  has_many :sendgrid_msg_events
+
   def message
     Message.find_by(sendgrid_msg_id: id)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,11 @@ Rails.application.routes.draw do
   namespace :site_admin, path: '/admin' do
       resources :api_keys
       resources :clearstream_msgs
+      resources :clearstream_msg_events
       resources :managers
       resources :messages
       resources :sendgrid_msgs
+      resources :sendgrid_msg_events
       resources :teams
       resources :templates
       resources :receivers


### PR DESCRIPTION
- Create Adimin Dashboards
-- rails g administrate:dashboard SendgridMsgEvent
-- rails g administrate:dashboard ClearstreamEvent
- Update models
-- Add has_many :sendgrid_msg_events SendgridMsg
-- Add has_many :clearstream_msg_events to ClearstreamMsg
- Add new routes to namespace :site_admin, path: '/admin'
-- resources :clearstream_msg_events
-- resources :sendgrid_msg_events
- Add gem 'administrate-field-nested_has_many'
- Some rubocop style fixes
- Fix ID field for ClearstreamMsgDashboard: make it a Field:String