### PR TITLE
Address FIXME's (except the sendgrid/sections one)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,3 +77,21 @@ blocks:
           value: f8848b7ae9da83a65f6f0f6ed462f01c
         - name: DATABASE_URL
           value: postgresql://postgres@localhost/test?encoding=utf8
+        - name: APP_NAME
+          value: uhura
+        - name: API_VER_NO
+          value: 1
+        - name: API_VER
+          value: api/v1
+        - name: APP_DOMAIN
+          value: localhost:3000
+        - name: APP_PROTOCOL
+          value: http://
+        - name: BASE_URI
+          value: http://localhost:3000
+        - name: API_ENDPOINT
+          value: http://localhost:3000/api/v1/
+        - name: ADMIN_PATH
+          value: /admin
+        - name: NUMBER_OF_SLOW_TESTS_TO_DISPLAY
+          value: 2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,7 @@ blocks:
         - name: APP_NAME
           value: uhura
         - name: API_VER_NO
-          value: 1
+          value: '1'
         - name: API_VER
           value: api/v1
         - name: APP_DOMAIN
@@ -94,4 +94,4 @@ blocks:
         - name: ADMIN_PATH
           value: /admin
         - name: NUMBER_OF_SLOW_TESTS_TO_DISPLAY
-          value: 2
+          value: '2'

--- a/Envfile
+++ b/Envfile
@@ -1,7 +1,7 @@
-# Most of the things are optional. If you need to use a
-# custom key, please create an application.yml for it
-
-enable_defaults! { ENV["RACK_ENV"] != "production" }
+# Default values will be/has been removed from ENVied (i.e. version > v0.9).
+# For more info see https://gitlab.com/envied/envied/tree/0-9-releases#defaults
+# enable_defaults! { ENV["RACK_ENV"] != "production" }
+# The implication is that you should populate the environment variables for each environment.
 
 #-----------------------------------------------
 #              Basic Configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/thoughtbot/administrate.git
-  revision: f17793a731818eba0b3357d71f0f1ae55ddcce13
+  revision: 8e13a25ef2ef53132cfff368aa8c2652469251b8
   specs:
     administrate (0.11.0)
       actionpack (>= 4.2)
@@ -125,7 +125,7 @@ GEM
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    excon (0.65.0)
+    excon (0.66.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -48,7 +48,7 @@ class Api::V1::MessagesController < Api::V1::ApiBaseController
     invalid_message = InvalidMessage.create!(
       message_vo.invalid_message_attrs.merge(
         message_params: message_params_vo.message_params,
-        message_attrs: message_vo.to_hash.merge(errors: errors)
+        message_attrs: message_vo.to_h.merge(errors: errors)
       )
     )
     render_error_status(invalid_message.id)

--- a/app/models/manager_team_vo.rb
+++ b/app/models/manager_team_vo.rb
@@ -13,8 +13,7 @@ class ManagerTeamVo < BaseClass
   attr_accessor :manager_id,
                 :manager_name,
                 :manager_email,
-                :team_name,
-                :my_attributes
+                :team_name
 
   def initialize(*args)
     super(args[0])

--- a/app/models/message_params_vo.rb
+++ b/app/models/message_params_vo.rb
@@ -19,8 +19,7 @@ class MessageParamsVo < BaseClass
                 :email_message,
                 :email_options,
                 :template_id,
-                :sms_message,
-                :my_attributes
+                :sms_message
 
   def initialize(*args)
     super(args[0])

--- a/app/models/message_vo.rb
+++ b/app/models/message_vo.rb
@@ -61,7 +61,7 @@ class MessageVo
 
   def init_attributes(message_params_vo, manager_team_vo)
     # Valid input. Now, perform lookups to fill in missing data prior to processing request.
-    assign_attributes(message_params_vo.my_attrs.merge(manager_team_vo.my_attrs))
+    assign_attributes(message_params_vo.to_h.merge(manager_team_vo.to_h))
 
     ret = Receiver.from_user_preferences(
       highlands_data: {
@@ -140,15 +140,13 @@ class MessageVo
     }
   end
 
-  def to_hash
-    # FIXME: I don't like us mapping over any instance variables to do this,
-    # I'd prefer if we could be explicit about the to_hash. also, `to_h` is the
-    # right name for a method that does this in ruby If we add an instance
-    # variable in the future it could break something elsewhere and it'd be a
-    # bear to track it to here
-    Hash[instance_variables.map do |name|
-      # Strip "@"  Example: {"@first": "Cindy"} => {"first": "Cindy"}
-      [name[1..-1], instance_variable_get(name)] unless name.eql?('@errors')
-    end ]
+  # Return a hash that includes all instance variables, less the errors attribute.
+  def to_h
+    h = {}
+    instance_variables.map do |name|
+      # name[1..-1] strips the "@"  Example: {"@first": "Cindy"} => {"first": "Cindy"}
+      h[name[1..-1]] = instance_variable_get(name) unless name.to_s.eql?('@errors')
+    end
+    h
   end
 end

--- a/app/models/receiver.rb
+++ b/app/models/receiver.rb
@@ -9,7 +9,6 @@ class Receiver < ApplicationRecord
   validates :mobile_number, presence: true
   validates :preferences, presence: true
 
-  # FIXME: This should probably just be `#to_s`
   def to_name
     "#{first_name} #{last_name}".strip
   end

--- a/app/models/return_vo.rb
+++ b/app/models/return_vo.rb
@@ -10,7 +10,6 @@ class ReturnVo
 
   validate :concistency_check
 
-  # FIXME: Maybe nothing to fix here, but why is this ActiveModel.initialize instead of just initialize?
   def ActiveModel.initialize(*args)
     super
     validate!

--- a/app/models/sendgrid_mail_vo.rb
+++ b/app/models/sendgrid_mail_vo.rb
@@ -82,34 +82,34 @@ class SendgridMailVo
     { mail: mail, personalization: personalization }
   end
 
+  def self.email_address_and_name(email_and_maybe_name)
+    maybe_name_array = email_and_maybe_name.strip.gsub('  ', ' ').split(' ')
+    email_address = maybe_name_array[0]
+    email_name = maybe_name_array[1..-1].join(' ')[1..-2] if maybe_name_array.size > 1
+    { email: email_address, name: email_name }
+  end
+
   def self.extract_cc(personalization, value)
     # ["recipient1@example.com <Alice Recipient>","recipient2@example.com"]
     value.each do |i|
-      cc_maybe_name_array = i.strip.gsub('  ', ' ').split(' ')
-      cc = cc_maybe_name_array[0]
-      cc_name = cc_maybe_name_array[1..-1].join(' ')[1..-2] if cc_maybe_name_array.size > 1
-      personalization.add_cc(Email.new(email: cc, name: cc_name))
+      email_name = email_address_and_name(i)
+      personalization.add_cc(Email.new(email: email_name[:email], name: email_name[:name]))
     end
     personalization
   end
 
-  # FIXME: We use this same code three times, can we reuse this instead?
   def self.extract_bcc(personalization, value)
     # ["recipient3@example.com","recipient4@example.com <Bob Recipient>"]
     value.each do |i|
-      bcc_maybe_name_array = i.strip.gsub('  ', ' ').split(' ')
-      bcc = bcc_maybe_name_array[0]
-      bcc_name = bcc_maybe_name_array[1..-1].join(' ')[1..-2] if bcc_maybe_name_array.size > 1
-      personalization.add_bcc(Email.new(email: bcc, name: bcc_name))
+      email_name = email_address_and_name(i)
+      personalization.add_bcc(Email.new(email: email_name[:email], name: email_name[:name]))
     end
     personalization
   end
 
   def self.extract_reply_to(value)
-    reply_to_maybe_name_array = value.strip.gsub('  ', ' ').split(' ')
-    reply_to = reply_to_maybe_name_array[0]
-    reply_to_name = reply_to_maybe_name_array[1..-1].join(' ')[1..-2] if reply_to_maybe_name_array.size > 1
-    Email.new(email: reply_to, name: reply_to_name)
+    email_name = email_address_and_name(value)
+    Email.new(email: email_name[:email], name: email_name[:name])
   end
 
   def self.mail(mail_vo)

--- a/app/services/base_class.rb
+++ b/app/services/base_class.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BaseClass
+  attr_accessor :my_attributes
+
   def self.attr_accessor(*vars)
     @attributes ||= []
     @attributes.concat vars
@@ -15,13 +17,14 @@ class BaseClass
     self.class.attributes
   end
 
-  # FIXME: Explain this to me at least, if we need it. It feels really weird.
-  def my_attrs
-    self.my_attributes = {} if my_attributes.nil?
-    attributes.reject { |attr| attr == :validation_context }.each do |i|
-      my_attributes[i] = send(i.to_s)
+  # Return a hash that includes all instance variables, less the errors and validation_context attributes.
+  def to_h
+    h = {}
+    instance_variables.map do |name|
+      unless name.to_s.eql?('@errors') || name.to_s.eql?('@validation_context')
+        h[name[1..-1]] = instance_variable_get(name)
+      end
     end
-    my_attributes.delete(:my_attributes)
-    my_attributes
+    h
   end
 end

--- a/app/services/clearstream_handler.rb
+++ b/app/services/clearstream_handler.rb
@@ -36,7 +36,7 @@ class ClearstreamHandler < ServiceHandlerBase
         "action_required:": action_msg
       }
     end
-    handle_clearstream_msg_error(err_msg, clearstream_vo, message_vo)
+    handle_clearstream_msg_error(err_msg, message_vo)
   end
   # rubocop:enable Metrics/MethodLength
 
@@ -49,7 +49,7 @@ class ClearstreamHandler < ServiceHandlerBase
     ).vo
   end
 
-  def self.handle_clearstream_msg_error(err_msg, _clearstream_vo, message_vo)
+  def self.handle_clearstream_msg_error(err_msg, message_vo)
     log_error(err_msg)
     # An error occurs while processing the request. Record ERROR status.
     clearstream_msg = ClearstreamMsg.create!(

--- a/app/workers/sendgrid_message_worker.rb
+++ b/app/workers/sendgrid_message_worker.rb
@@ -5,7 +5,6 @@ class SendgridMessageWorker
   sidekiq_options retry: false
 
   def perform(sendgrid_vo)
-    # FIXME: sendgrid_vo = nil # <= create error
     SendgridHandler.send_msg(sendgrid_vo)
   end
 end


### PR DESCRIPTION
This addresses FIXME's (except the sendgrid/sections one)

- Replace  my_attrs (using attributes and send) with to_h (using instance_variables)
- Remove my_attributes attribute from manager_team_vo and message_params_vo
- ActiveModel.initialize is used instead of just initialize to be explicit about where the validate! comes from
- Refactor: create email_address_and_name helper in sendgrid_mail_vo
- Remove needless param _clearstream_vo from handle_clearstream_msg_error
- Comment out enable_defaults! { ENV["RACK_ENV"] != "production" } and document in Envfile
- Upgrade excon gem from (0.65.0) to (0.66.0)